### PR TITLE
[ContentApply] 지원 및 지원 승인 기능 구현

### DIFF
--- a/server/src/main/java/com/gigker/server/domain/content/controller/ContentApplyController.java
+++ b/server/src/main/java/com/gigker/server/domain/content/controller/ContentApplyController.java
@@ -38,9 +38,9 @@ public class ContentApplyController {
 		@PathVariable("content-id") @Positive Long contentId,
 		@RequestBody @Valid ContentApplyDto.Post post) {
 
-		ContentApply apply = applyService.createApply();
-
-		ContentApplyDto.Response response = applyMapper.applyToResponse(apply);
+		ContentApply apply = applyMapper.postToApply(post, contentId);
+		ContentApply createdApply = applyService.createApply(apply);
+		ContentApplyDto.Response response = applyMapper.applyToResponse(createdApply);
 
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
@@ -51,7 +51,7 @@ public class ContentApplyController {
 		@PathVariable("content-id") @Positive Long contentId,
 		@PathVariable("content-apply-id") @Positive Long applyId) {
 
-		ContentApply apply = applyService.acceptApply();
+		ContentApply apply = applyService.acceptApply(applyId);
 
 		return ResponseEntity.ok().build();
 	}
@@ -72,7 +72,7 @@ public class ContentApplyController {
 		@PathVariable("content-id") @Positive Long contentId,
 		@PathVariable("content-apply-id") @Positive Long applyId) {
 
-		ContentApply apply = applyService.findApply();
+		ContentApply apply = applyService.findApply(applyId);
 
 		return ResponseEntity.status(HttpStatus.OK).body(null);
 	}

--- a/server/src/main/java/com/gigker/server/domain/content/dto/ContentApplyDto.java
+++ b/server/src/main/java/com/gigker/server/domain/content/dto/ContentApplyDto.java
@@ -1,6 +1,6 @@
 package com.gigker.server.domain.content.dto;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +12,7 @@ public class ContentApplyDto {
 	@NoArgsConstructor
 	public static class Post {
 		// TODO : 인증이 구현되면 Post 삭제
-		@NotBlank(message = "applicantId must not be null")
+		@NotNull(message = "applicantId must not be null")
 		private Long applicantId;
 	}
 

--- a/server/src/main/java/com/gigker/server/domain/content/entity/Content.java
+++ b/server/src/main/java/com/gigker/server/domain/content/entity/Content.java
@@ -27,7 +27,7 @@ public class Content extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long contentId;
 
-	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 //	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Member member;

--- a/server/src/main/java/com/gigker/server/domain/content/entity/ContentApply.java
+++ b/server/src/main/java/com/gigker/server/domain/content/entity/ContentApply.java
@@ -56,7 +56,11 @@ public class ContentApply extends BaseEntity {
 		}
 	}
 
-	public void changeStatus(ApplyStatus applyStatus) {
-		this.applyStatus = applyStatus;
+	public void accept() {
+		this.applyStatus = ApplyStatus.MATCH;
+	}
+
+	public void complete() {
+		this.applyStatus = ApplyStatus.COMPLETE;
 	}
 }

--- a/server/src/main/java/com/gigker/server/domain/content/mapper/ContentApplyMapper.java
+++ b/server/src/main/java/com/gigker/server/domain/content/mapper/ContentApplyMapper.java
@@ -1,6 +1,7 @@
 package com.gigker.server.domain.content.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 import com.gigker.server.domain.content.dto.ContentApplyDto;
@@ -11,13 +12,12 @@ import com.gigker.server.domain.content.entity.ContentApply;
 	unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ContentApplyMapper {
 
-	// TODO : Member, Content의 Mapper가 만들어지면 매핑
-	// @Mapping(target = "applicant", source = "member")
-	// @Mapping(target = "content", source = "content")
-	ContentApply postToApply(ContentApplyDto.Post post);
+	@Mapping(source = "post.applicantId", target = "applicant.memberId")
+	@Mapping(source = "contentId", target = "content.contentId")
+	ContentApply postToApply(ContentApplyDto.Post post, Long contentId);
 
-	// @Mapping(target = "nickName", source = "member.nickName")
-	// @Mapping(target = "pictureUrl", source = "member.pictureUrl")
-	// @Mapping(target = "about", source = "member.about")
+	@Mapping(source = "applicant.nickName", target = "nickName")
+	@Mapping(source = "applicant.pictureUrl", target = "pictureUrl")
+	@Mapping(source = "applicant.about", target = "about")
 	ContentApplyDto.Response applyToResponse(ContentApply apply);
 }

--- a/server/src/main/java/com/gigker/server/domain/content/repository/ContentApplyRepository.java
+++ b/server/src/main/java/com/gigker/server/domain/content/repository/ContentApplyRepository.java
@@ -1,5 +1,6 @@
 package com.gigker.server.domain.content.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import com.gigker.server.domain.member.entity.Member;
 
 public interface ContentApplyRepository extends JpaRepository<ContentApply, Long> {
 	Optional<ContentApply> findByApplicantAndContent(Member member, Content content);
+
+	List<ContentApply> findAllByContent(Content content);
 }

--- a/server/src/main/java/com/gigker/server/domain/content/service/ContentApplyService.java
+++ b/server/src/main/java/com/gigker/server/domain/content/service/ContentApplyService.java
@@ -4,12 +4,15 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gigker.server.domain.content.entity.Content;
 import com.gigker.server.domain.content.entity.ContentApply;
 import com.gigker.server.domain.content.repository.ContentApplyRepository;
 import com.gigker.server.domain.member.entity.Member;
+import com.gigker.server.domain.member.service.MemberService;
 import com.gigker.server.global.exception.BusinessLogicException;
 import com.gigker.server.global.exception.ExceptionCode;
 
@@ -20,20 +23,38 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ContentApplyService {
 	private final ContentApplyRepository applyRepository;
+	private final MemberService memberService;
+	private final ContentService contentService;
 
-	public ContentApply createApply() {
+	@Transactional
+	public ContentApply createApply(ContentApply apply) {
+		// Member, Content, ContentApply 유효성 검사
+		Member member = memberService.findMemberById(apply.getApplicant().getMemberId());
+		Content content = contentService.findContentByContentId(apply.getContent().getContentId());
+		verifyExistMemberApply(member, content);
 
-		return null;
+		return applyRepository.save(apply);
 	}
 
-	public ContentApply acceptApply() {
+	@Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+	public ContentApply acceptApply(Long applyId) {
+		// TODO: 추후 토큰의 memberId와 content.member.memberId 비교하는 로직 추가 (작성자만 승인 가능)
+		ContentApply apply = findVerifiedApply(applyId);
 
-		return null;
+		// 중복하여 변경 시도 시 throw Exception
+		if (apply.getApplyStatus() == ContentApply.ApplyStatus.NONE) {
+			apply.accept();
+		} else
+			throw new BusinessLogicException(ExceptionCode.EXISTS_APPLY);
+
+		otherApplicantsAutoDelete(apply.getContent());
+
+		return apply;
 	}
 
-	public ContentApply findApply() {
+	public ContentApply findApply(Long applyId) {
 
-		return null;
+		return findVerifiedApply(applyId);
 	}
 
 	public List<ContentApply> findAll() {
@@ -65,5 +86,14 @@ public class ContentApplyService {
 		if (optionalApply.isPresent()) {
 			throw new BusinessLogicException(ExceptionCode.EXISTS_APPLY);
 		}
+	}
+
+	// Accept 요청 발생 시, 나머지 지원자들 자동 취소 기능
+	private void otherApplicantsAutoDelete(Content content) {
+		List<ContentApply> contents = applyRepository.findAllByContent(content);
+
+		contents.stream()
+			.mapToLong(ContentApply::getContentApplyId)
+			.forEach(this::deleteApply);
 	}
 }

--- a/server/src/main/java/com/gigker/server/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/gigker/server/global/exception/ExceptionCode.java
@@ -7,7 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ExceptionCode {
 
+	// 400 Bad Request (잘못된 요구)
 	NO_PERMISSION(400, "No permission"), //권한이 없는 사용자의 요청
+	BAD_REQUEST_APPLY(400, "Writer cannot apply"),
+
 	// 404
 	NOT_FOUND_MEMBER(404, "Member not found"),
 	NOT_FOUND_CONTENT(404, "Content not found"),

--- a/server/src/main/java/com/gigker/server/global/exception/controller/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/gigker/server/global/exception/controller/GlobalExceptionAdvice.java
@@ -53,7 +53,7 @@ public class GlobalExceptionAdvice {
 	public ResponseEntity<ErrorResponse> handleBusinessLogicException(BusinessLogicException e) {
 		final ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
 
-		return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getCode() / 100));
+		return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getCode()));
 	}
 
 	@ExceptionHandler

--- a/server/src/test/java/com/gigker/server/domain/contentApply/service/ContentApplyServiceTest.java
+++ b/server/src/test/java/com/gigker/server/domain/contentApply/service/ContentApplyServiceTest.java
@@ -1,0 +1,171 @@
+package com.gigker.server.domain.contentApply.service;
+
+import static com.gigker.server.domain.stub.ContentApplyStubData.*;
+import static com.gigker.server.domain.stub.ContentStubData.*;
+import static com.gigker.server.domain.stub.MemberStubData.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.gigker.server.domain.content.entity.Content;
+import com.gigker.server.domain.content.entity.ContentApply;
+import com.gigker.server.domain.content.repository.ContentApplyRepository;
+import com.gigker.server.domain.content.repository.ContentRepository;
+import com.gigker.server.domain.content.service.ContentApplyService;
+import com.gigker.server.domain.content.service.ContentService;
+import com.gigker.server.domain.member.entity.Member;
+import com.gigker.server.domain.member.repository.MemberRepository;
+import com.gigker.server.domain.member.service.MemberService;
+import com.gigker.server.global.exception.BusinessLogicException;
+import com.gigker.server.global.exception.ExceptionCode;
+
+// @ActiveProfiles("local")
+@SpringBootTest
+@DisplayName("신청 기능 테스트")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ContentApplyServiceTest {
+	private List<Member> members;
+	private Content content;
+	private ContentApply badRequestApply;
+	private List<ContentApply> existApplies;
+
+	@Autowired
+	MemberService memberService;
+
+	@Autowired
+	ContentService contentService;
+
+	@Autowired
+	ContentApplyService applyService;
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	ContentRepository contentRepository;
+
+	@Autowired
+	ContentApplyRepository applyRepository;
+
+	@BeforeAll
+	void beforeAll() {
+		cleanRepository();
+
+		members = getMembers();
+		memberRepository.saveAll(members);
+
+		content = getContent();
+		contentRepository.save(content);
+
+		badRequestApply = getApply();
+		existApplies = getApplies();
+		applyRepository.saveAll(existApplies);
+	}
+
+	void cleanRepository() {
+		memberRepository.deleteAll();
+		contentRepository.deleteAll();
+		applyRepository.deleteAll();
+	}
+
+	@Nested
+	@DisplayName("게시글에 지원")
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	class Create {
+		@Test
+		void 존재하는_회원인지_검사한다() throws Exception {
+			// given
+			Long memberId = 10L;
+
+			// when then
+			BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+				() -> memberService.findMemberById(memberId));
+
+			assertEquals(ExceptionCode.NOT_FOUND_MEMBER, ex.getExceptionCode());
+		}
+
+		@Test
+		void 존재하는_게시글인지_검사한다() throws Exception {
+			// given
+			Long contentId = 10L;
+
+			// when then
+			BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+				() -> contentService.findContentByContentId(contentId));
+
+			assertEquals(ExceptionCode.NOT_FOUND_CONTENT, ex.getExceptionCode());
+		}
+
+		@Test
+		void 지원자가_작성자인지_검사한다() throws Exception {
+			BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+				() -> applyService.createApply(badRequestApply));
+
+			assertEquals(ExceptionCode.BAD_REQUEST_APPLY, ex.getExceptionCode());
+		}
+
+		@Test
+		void 이미_지원했는지_검사한다() throws Exception {
+			// then
+			BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+				() -> applyService.createApply(existApplies.get(0)));
+
+			assertEquals(ExceptionCode.EXISTS_APPLY, ex.getExceptionCode());
+		}
+	}
+
+	@Nested
+	@DisplayName("지원 요청 승인")
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	class Accept {
+		@Test
+		void 존재하는_지원인지_확인한다() throws Exception {
+			// given
+			Long applyId = 10L;
+
+			// when then
+			BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+				() -> applyService.findVerifiedApply(applyId));
+
+			assertEquals(ExceptionCode.NOT_FOUND_APPLY, ex.getExceptionCode());
+		}
+
+		@Test
+		void 지원요청_승인_시_나머지_지원자는_자동취소_됐는지_확인한다() throws Exception {
+			// given
+			Long applyId = existApplies.get(0).getContentApplyId();
+
+			// when
+			applyService.acceptApply(applyId);
+			Optional<ContentApply> optionalApply = applyRepository.findById(applyId);
+
+			// then
+			// 지원 요청이 승인 됐는지 확인
+			assertEquals(optionalApply.get().getApplyStatus(), ContentApply.ApplyStatus.MATCH);
+
+			// 나머지 지원자 자동취소 됐는지 확인
+			assertEquals(1, applyRepository.findAll().size());
+		}
+
+		@Test
+		void 중복된_지원인지_확인한다() throws Exception {
+			// given
+			Long applyId = existApplies.get(0).getContentApplyId();
+
+			// when then
+			BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+				() -> applyService.acceptApply(applyId));
+
+			assertEquals(ExceptionCode.EXISTS_APPLY, ex.getExceptionCode());
+		}
+	}
+}

--- a/server/src/test/java/com/gigker/server/domain/stub/ContentApplyStubData.java
+++ b/server/src/test/java/com/gigker/server/domain/stub/ContentApplyStubData.java
@@ -1,0 +1,35 @@
+package com.gigker.server.domain.stub;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.gigker.server.domain.content.entity.ContentApply;
+
+public class ContentApplyStubData {
+	public static ContentApply getApply() {
+
+		return ContentApply.builder()
+			.contentApplyId(1L)
+			.applicant(MemberStubData.getMember())
+			.content(ContentStubData.getContent())
+			.applyStatus(ContentApply.ApplyStatus.NONE)
+			.build();
+	}
+
+	public static List<ContentApply> getApplies() {
+		List<ContentApply> applies = new ArrayList<>();
+
+		for (int i = 1; i <= 4; i++) {
+			ContentApply apply = ContentApply.builder()
+				.contentApplyId((long) i)
+				.applicant(MemberStubData.getMembers().get(i))
+				.content(ContentStubData.getContent())
+				.applyStatus(ContentApply.ApplyStatus.NONE)
+				.build();
+
+			applies.add(apply);
+		}
+
+		return applies;
+	}
+}

--- a/server/src/test/java/com/gigker/server/domain/stub/ContentStubData.java
+++ b/server/src/test/java/com/gigker/server/domain/stub/ContentStubData.java
@@ -1,0 +1,22 @@
+package com.gigker.server.domain.stub;
+
+import com.gigker.server.domain.common.ContentType;
+import com.gigker.server.domain.content.entity.Content;
+
+public class ContentStubData {
+
+	public static Content getContent() {
+		Content content = new Content();
+		content.setContentId(1L);
+		content.setMember(MemberStubData.getMember());
+		content.setContentType(ContentType.BUY);
+		content.setTitle("제목");
+		content.setWorkContent("일할 사람");
+		// content.setCategory();
+		content.setLocation("444123");
+		content.setPrice(100000);
+		content.setStatus(Content.Status.RECRUITING);
+
+		return content;
+	}
+}

--- a/server/src/test/java/com/gigker/server/domain/stub/MemberStubData.java
+++ b/server/src/test/java/com/gigker/server/domain/stub/MemberStubData.java
@@ -1,0 +1,41 @@
+package com.gigker.server.domain.stub;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.gigker.server.domain.member.entity.Member;
+
+public class MemberStubData {
+
+	// getMember 정보는 getMembers.get(0) 정보와 같다.
+	public static Member getMember() {
+		return Member.builder()
+			.memberId(1L)
+			.email("user01@hello.com")
+			.password("0001")
+			.nickName("user01")
+			.about("편돌이 1년차")
+			.pictureUrl("asd")
+			.memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
+			.build();
+	}
+
+	public static List<Member> getMembers() {
+		List<Member> members = new ArrayList<>();
+
+		for (int i = 1; i <= 5; i++) {
+			Member member = Member.builder()
+				.memberId((long)i)
+				.email(String.format("user%02d@hello.com", i))
+				.password(String.format("%04d", i))
+				.nickName(String.format("user%02d", i))
+				.about("편돌이 1년차")
+				.pictureUrl("asd")
+				.memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
+				.build();
+
+			members.add(member);
+		}
+		return members;
+	}
+}


### PR DESCRIPTION
## 개요
- 💡 Issue(#20 )

## 작업 사항
- 게시글에 지원 요청을 보내는 로직 구현 ```/contents/{content-id}/apply```

- 지원 요청을 승인하는 로직 구현 ```/contents/{content-id}/apply/{content-apply-id}```

   - 지원 요청 승인 시 해당 content에 요청한 지원자 자동 취소 기능 구현

## 추가 작업 사항
- ExceptionCode 추가 및 BusinessLogicException이 Response 되지 않는 문제 수정

- 글 작성자는 신청하지 못하는 로직 추가

- 기존 신청자 자동 취소 기능의 오작동이 있어서 해당 부분 수정

- content와 member 사이의 영속성 재조정

- 구현한 기능에 대한 단위테스트