### PR TITLE
[Content] 게시글 조회 로직 개선

### DIFF
--- a/server/src/main/java/com/gigker/server/domain/content/controller/ContentController.java
+++ b/server/src/main/java/com/gigker/server/domain/content/controller/ContentController.java
@@ -11,13 +11,18 @@ import com.gigker.server.domain.content.service.ContentService;
 import com.gigker.server.domain.location.entity.Location;
 import com.gigker.server.domain.location.service.LocationService;
 import com.gigker.server.domain.review.service.ReviewService;
+import com.gigker.server.global.dto.MultiResponseDto;
 import com.gigker.server.global.dto.SingleResponseDto;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+
 import java.util.List;
 import java.util.Map;
 
@@ -87,6 +92,19 @@ public class ContentController {
         return new ResponseEntity<>(
                 (new SingleResponseDto<>(contentMapper.contentsToSimpleContents(contents))),
                 HttpStatus.OK);
+    }
+
+    @GetMapping("/by")
+    public ResponseEntity getContents(
+        @RequestParam(value = "category", required = false) Category category,
+        @RequestParam(value = "location", required = false) Location location,
+        @RequestParam @Positive int page
+    ) {
+        Page<Content> pageContents = contentService.findAllBy(category, location, page);
+        List<Content> contents = pageContents.getContent();
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(new MultiResponseDto<>(contentMapper.contentsToSimpleContents(contents), pageContents));
     }
 
     @DeleteMapping("/{content_id}")

--- a/server/src/main/java/com/gigker/server/domain/content/entity/Content.java
+++ b/server/src/main/java/com/gigker/server/domain/content/entity/Content.java
@@ -13,10 +13,12 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import com.gigker.server.domain.category.entity.Category;
 import com.gigker.server.domain.common.BaseEntity;
@@ -33,6 +35,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Data
 @NoArgsConstructor
+@Table(indexes = {
+	@Index(name = "idx__category_location", columnList = "category_id, location_id")
+})
 public class Content extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/com/gigker/server/domain/content/repository/ContentRepository.java
+++ b/server/src/main/java/com/gigker/server/domain/content/repository/ContentRepository.java
@@ -2,6 +2,9 @@ package com.gigker.server.domain.content.repository;
 
 import com.gigker.server.domain.category.entity.Category;
 import com.gigker.server.domain.common.ContentType;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gigker.server.domain.content.entity.Content;
+import com.gigker.server.domain.location.entity.Location;
 
 import java.util.List;
 
@@ -16,10 +20,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
     List<Content> findContentsByContentType(ContentType contentType);
 
-
     List<Content> findAllByStatusAndContentType(Content.Status status, ContentType type);
-
-    List<Content> findContentsByCategory(Category category);
 
     // == DeadLine Management ==
     @Query("select c from Content c where c.status = :status")
@@ -29,4 +30,13 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update Content c set c.status = 'RECRUITING' where c.contentId in :ids")
     void updateContentStatusByIds(@Param("ids") List<Long> contentIds);
+
+    // == Get ==
+    Page<Content> findAll(Pageable pageable);
+
+    Page<Content> findAllByCategory(Category category, Pageable pageable);
+
+    Page<Content> findAllByLocation(Location location, Pageable pageable);
+
+    Page<Content> findAllByCategoryAndLocation(Category category, Location location, Pageable pageable);
 }

--- a/server/src/main/java/com/gigker/server/domain/content/service/ContentService.java
+++ b/server/src/main/java/com/gigker/server/domain/content/service/ContentService.java
@@ -3,6 +3,9 @@ package com.gigker.server.domain.content.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,7 +78,22 @@ public class ContentService {
 		contentRepository.delete(findContent);
 	}
 
-	public List<Content> findContentsByCategory(Category category) {
-		return contentRepository.findContentsByCategory(category);
+	public Page<Content> findAllBy(Category category, Location location, int page) {
+		final int size = 12;
+		Pageable pageable = PageRequest.of(page, size);
+
+		if (category == null && location == null) {
+			return contentRepository.findAll(pageable);
+		}
+
+		if (location == null) {
+			return contentRepository.findAllByCategory(category, pageable);
+		}
+
+		if (category == null) {
+			return contentRepository.findAllByLocation(location, pageable);
+		}
+
+		return contentRepository.findAllByCategoryAndLocation(category, location, pageable);
 	}
 }


### PR DESCRIPTION
## 개요
- 💡 Issue(#160 )

## 작업 사항
- 카테고리 및 지역 id를 통한 조회 기능 추가  

> 💡API 예시 
> ```/contents/by?location=1&page=1```
> ```/contents/by?category=1&location=1&page=1```
>
> category와 location은 **nullable**, 미 작성 시에도 조회 가능

- Category, Location 칼럼에 인덱스 추가를 통한 쿼리 속도 개선

## 기타
- 페이지네이션 size는 현재 디자인을 고려해 12로 고정